### PR TITLE
Add support for alpha and beta tags for PEP versioning format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - tree
   # install DepHell
   # https://github.com/travis-ci/travis-ci/issues/8589
-  - curl https://raw.githubusercontent.com/dephell/dephell/master/install.py | /opt/python/3.6/bin/python
+  - curl https://raw.githubusercontent.com/dephell/dephell/master/install.py | /opt/python/3.7/bin/python
   - dephell inspect self
 install:
   - dephell venv create --env=$ENV --python="/opt/python/$TRAVIS_PYTHON_VERSION/bin/python"
@@ -17,16 +17,16 @@ script:
 
 matrix:
   include:
-    - python: "3.5"
+    - python: "3.6.7"
       env: ENV=pytest
-    - python: "3.6"
+    - python: "3.7"
       env: ENV=pytest
-    - python: "3.7-dev"
+    - python: "3.8"
       env: ENV=pytest
-    - python: "pypy3.5"
+    - python: "pypy3"
       env: ENV=pytest
 
-    - python: "3.6"
+    - python: "3.7"
       env: ENV=flake8
-    - python: "3.6"
+    - python: "3.7"
       env: ENV=typing

--- a/dephell_versioning/_schemes/_base.py
+++ b/dephell_versioning/_schemes/_base.py
@@ -15,10 +15,6 @@ class BaseScheme(ABC):
         fix='patch',
         micro='patch',
 
-        rc='pre',
-        alpha='pre',
-        beta='pre',
-
         prebreaking='premajor',
         prefeature='preminor',
         prefix='prepatch',

--- a/dephell_versioning/_schemes/_pep.py
+++ b/dephell_versioning/_schemes/_pep.py
@@ -8,7 +8,46 @@ class PEPScheme(SemVerScheme):
     https://www.python.org/dev/peps/pep-0440/#version-scheme
     """
 
+    _alpha = 'alpha'
+    _beta = 'beta'
     _rc = 'rc'  # PEP has different pre-release syntax
+
+    pre_mapping=dict(
+        a=_alpha,
+        b=_beta,
+        rc=_rc
+    )
+    def bump_pre(self, version: Union[Version, str]) -> str:
+        if isinstance(version, str):
+            version = Version(version)
+        parts = self._get_parts(version)
+        if version.pre:
+            pre = version.pre[1]
+            return '{}.{}.{}{}{}'.format(*parts[:3],self.pre_mapping[version.pre[0]], pre+1)
+        else:
+            return '{}.{}.{}{}{}'.format(*parts[:3], self._alpha, 1)
+
+    def bump_alpha(self, version: Union[Version, str]) -> str:
+        if isinstance(version, str):
+            version = Version(version)
+        parts = self._get_parts(version)
+        alpha = version.pre[1] if (version.pre and version.pre[0] == 'a') else 0
+        return '{}.{}.{}{}{}'.format(*parts[:3], self._alpha, alpha+1)
+
+    def bump_beta(self, version: Union[Version, str]) -> str:
+        if isinstance(version, str):
+            version = Version(version)
+        parts = self._get_parts(version)
+        beta = version.pre[1] if (version.pre and version.pre[0] == 'b') else 0
+        return '{}.{}.{}{}{}'.format(*parts[:3], self._beta, beta+1)
+
+    def bump_rc(self, version: Union[Version, str]) -> str:
+        if isinstance(version, str):
+            version = Version(version)
+        parts = self._get_parts(version)
+        rc = version.pre[1] if (version.pre and version.pre[0] == 'rc') else 0
+        return '{}.{}.{}{}{}'.format(*parts[:3], self._rc, rc+1)
+
 
     def bump_local(self, version: Union[Version, str]) -> str:
         if isinstance(version, str):

--- a/dephell_versioning/_schemes/_pep.py
+++ b/dephell_versioning/_schemes/_pep.py
@@ -8,46 +8,46 @@ class PEPScheme(SemVerScheme):
     https://www.python.org/dev/peps/pep-0440/#version-scheme
     """
 
-    _alpha = 'alpha'
-    _beta = 'beta'
+    _alpha = 'a'
+    _beta = 'b'
     _rc = 'rc'  # PEP has different pre-release syntax
 
-    pre_mapping=dict(
+    pre_mapping = dict(
         a=_alpha,
         b=_beta,
         rc=_rc
     )
+
     def bump_pre(self, version: Union[Version, str]) -> str:
         if isinstance(version, str):
             version = Version(version)
         parts = self._get_parts(version)
         if version.pre:
             pre = version.pre[1]
-            return '{}.{}.{}{}{}'.format(*parts[:3],self.pre_mapping[version.pre[0]], pre+1)
+            return '{}.{}.{}{}{}'.format(*parts[:3], self.pre_mapping[version.pre[0]], pre + 1)
         else:
-            return '{}.{}.{}{}{}'.format(*parts[:3], self._alpha, 1)
+            return '{}.{}.{}{}{}'.format(*parts[:3], self._rc, 1)
 
     def bump_alpha(self, version: Union[Version, str]) -> str:
         if isinstance(version, str):
             version = Version(version)
         parts = self._get_parts(version)
         alpha = version.pre[1] if (version.pre and version.pre[0] == 'a') else 0
-        return '{}.{}.{}{}{}'.format(*parts[:3], self._alpha, alpha+1)
+        return '{}.{}.{}{}{}'.format(*parts[:3], self._alpha, alpha + 1)
 
     def bump_beta(self, version: Union[Version, str]) -> str:
         if isinstance(version, str):
             version = Version(version)
         parts = self._get_parts(version)
         beta = version.pre[1] if (version.pre and version.pre[0] == 'b') else 0
-        return '{}.{}.{}{}{}'.format(*parts[:3], self._beta, beta+1)
+        return '{}.{}.{}{}{}'.format(*parts[:3], self._beta, beta + 1)
 
     def bump_rc(self, version: Union[Version, str]) -> str:
         if isinstance(version, str):
             version = Version(version)
         parts = self._get_parts(version)
         rc = version.pre[1] if (version.pre and version.pre[0] == 'rc') else 0
-        return '{}.{}.{}{}{}'.format(*parts[:3], self._rc, rc+1)
-
+        return '{}.{}.{}{}{}'.format(*parts[:3], self._rc, rc + 1)
 
     def bump_local(self, version: Union[Version, str]) -> str:
         if isinstance(version, str):

--- a/dephell_versioning/_schemes/_semver.py
+++ b/dephell_versioning/_schemes/_semver.py
@@ -44,13 +44,16 @@ class SemVerScheme(BaseScheme):
         return '{}.{}.{}{}+{}'.format(*parts[:3], pre, local + 1)
 
     def bump_premajor(self, version: Union[Version, str]) -> str:
-        return self.bump_major(version=version) + self._rc + '1'
+        new_version = self.bump_major(version=version)
+        return self.bump_pre(version=new_version)
 
     def bump_preminor(self, version: Union[Version, str]) -> str:
-        return self.bump_minor(version=version) + self._rc + '1'
+        new_version = self.bump_minor(version=version)
+        return self.bump_pre(version=new_version)
 
     def bump_prepatch(self, version: Union[Version, str]) -> str:
-        return self.bump_patch(version=version) + self._rc + '1'
+        new_version = self.bump_patch(version=version)
+        return self.bump_pre(version=new_version)
 
     def bump_release(self, version: Union[Version, str]) -> str:
         parts = self._get_parts(version)

--- a/tests/test_pep.py
+++ b/tests/test_pep.py
@@ -12,12 +12,30 @@ from dephell_versioning import bump_version
     ('patch',    '1.2.3', '1.2.4'),
 
     # pre-base version
-    ('premajor', '1.2.3', '2.0.0rc1'),
-    ('preminor', '1.2.3', '1.3.0rc1'),
-    ('prepatch', '1.2.3', '1.2.4rc1'),
+    ('premajor', '1.2.3', '2.0.0alpha1'),
+    ('preminor', '1.2.3', '1.3.0alpha1'),
+    ('prepatch', '1.2.3', '1.2.4alpha1'),
+
+    # add pep specific parts
+    ('pre',      '1.2.3', '1.2.3alpha1'), # pre will now append the first value in ('alpha', 'beta', 'rc')
+    ('alpha',    '1.2.3', '1.2.3alpha1'),
+    ('beta',     '1.2.3', '1.2.3beta1'),
+    ('rc',       '1.2.3', '1.2.3rc1'),
+
+    # update alpha -> beta -> rc
+    ('beta',     '1.2.3alpha1', '1.2.3beta1'),
+    ('rc',       '1.2.3beta1',  '1.2.3rc1'),
+
+    # bump alpha, beta, rc
+    ('alpha',    '1.2.3alpha1', '1.2.3alpha2'),
+    ('pre',      '1.2.3alpha1', '1.2.3alpha2'),
+    ('beta',     '1.2.3beta1',  '1.2.3beta2'),
+    ('pre',      '1.2.3beta1',  '1.2.3beta2'),
+    ('rc',       '1.2.3rc1',    '1.2.3rc2'),
+    ('pre',      '1.2.3rc1',    '1.2.3rc2'),
 
     # add special part
-    ('pre',      '1.2.3', '1.2.3rc1'),
+    #('pre',      '1.2.3', '1.2.3rc1'), # disabled because of changes in bump_pre implementation
     ('post',     '1.2.3', '1.2.3.post1'),
     ('dev',      '1.2.3', '1.2.3.dev1'),
     ('local',    '1.2.3', '1.2.3+1'),
@@ -36,4 +54,4 @@ from dephell_versioning import bump_version
 
 ])
 def test_bump_version(rule, old, new):
-    assert bump_version(rule=rule, version=old, scheme='pep') == new
+    assert bump_version(rule=rule, version=old, scheme='pep') == new, "Rule {} failed for '{}'!".format(rule, old)

--- a/tests/test_pep.py
+++ b/tests/test_pep.py
@@ -12,30 +12,30 @@ from dephell_versioning import bump_version
     ('patch',    '1.2.3', '1.2.4'),
 
     # pre-base version
-    ('premajor', '1.2.3', '2.0.0alpha1'),
-    ('preminor', '1.2.3', '1.3.0alpha1'),
-    ('prepatch', '1.2.3', '1.2.4alpha1'),
+    ('premajor', '1.2.3', '2.0.0rc1'),
+    ('preminor', '1.2.3', '1.3.0rc1'),
+    ('prepatch', '1.2.3', '1.2.4rc1'),
 
     # add pep specific parts
-    ('pre',      '1.2.3', '1.2.3alpha1'), # pre will now append the first value in ('alpha', 'beta', 'rc')
-    ('alpha',    '1.2.3', '1.2.3alpha1'),
-    ('beta',     '1.2.3', '1.2.3beta1'),
+    ('pre',      '1.2.3', '1.2.3rc1'),
+    ('alpha',    '1.2.3', '1.2.3a1'),
+    ('beta',     '1.2.3', '1.2.3b1'),
     ('rc',       '1.2.3', '1.2.3rc1'),
 
     # update alpha -> beta -> rc
-    ('beta',     '1.2.3alpha1', '1.2.3beta1'),
-    ('rc',       '1.2.3beta1',  '1.2.3rc1'),
+    ('beta',     '1.2.3a1', '1.2.3b1'),
+    ('rc',       '1.2.3b1', '1.2.3rc1'),
 
     # bump alpha, beta, rc
-    ('alpha',    '1.2.3alpha1', '1.2.3alpha2'),
-    ('pre',      '1.2.3alpha1', '1.2.3alpha2'),
-    ('beta',     '1.2.3beta1',  '1.2.3beta2'),
-    ('pre',      '1.2.3beta1',  '1.2.3beta2'),
-    ('rc',       '1.2.3rc1',    '1.2.3rc2'),
-    ('pre',      '1.2.3rc1',    '1.2.3rc2'),
+    ('alpha',    '1.2.3a1',  '1.2.3a2'),
+    ('pre',      '1.2.3a1',  '1.2.3a2'),
+    ('beta',     '1.2.3b1',  '1.2.3b2'),
+    ('pre',      '1.2.3b1',  '1.2.3b2'),
+    ('rc',       '1.2.3rc1', '1.2.3rc2'),
+    ('pre',      '1.2.3rc1', '1.2.3rc2'),
 
     # add special part
-    #('pre',      '1.2.3', '1.2.3rc1'), # disabled because of changes in bump_pre implementation
+    ('pre',      '1.2.3', '1.2.3rc1'),
     ('post',     '1.2.3', '1.2.3.post1'),
     ('dev',      '1.2.3', '1.2.3.dev1'),
     ('local',    '1.2.3', '1.2.3+1'),
@@ -54,4 +54,5 @@ from dephell_versioning import bump_version
 
 ])
 def test_bump_version(rule, old, new):
-    assert bump_version(rule=rule, version=old, scheme='pep') == new, "Rule {} failed for '{}'!".format(rule, old)
+    assert bump_version(rule=rule, version=old, scheme='pep') == new,\
+        "Rule {} failed for '{}'!".format(rule, old)


### PR DESCRIPTION
This change adds functionality as mentioned in Issue #3 .

Now you have the additional commands
**alpha**, **beta** and **rc** for the PEP versioning format to manage versions with pre-version tags like **1.2.3alpha1**, **1.2.3beta2** and **1.2.3rc3** as usual.

The command **pre** will update the number of those tags. If no tag exists, **pre** will add the **alpha** flag, otherwise the commands will add their corresponding flag to the version.